### PR TITLE
[BE] Issue Detail Patch API 구현, Issue 상세보기 시 Assignee 정보도 반환

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Assignee.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Assignee.java
@@ -1,0 +1,21 @@
+package kr.codesquad.issuetracker09.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class Assignee {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "issue_id")
+    private Issue issue;
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Assignee.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Assignee.java
@@ -1,9 +1,15 @@
 package kr.codesquad.issuetracker09.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Entity
 public class Assignee {

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/AssigneeRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/AssigneeRepository.java
@@ -1,0 +1,9 @@
+package kr.codesquad.issuetracker09.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AssigneeRepository extends JpaRepository<Assignee, Long> {
+    List<Assignee> findAssigneesByIssue_Id(Long id);
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/AssigneeRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/AssigneeRepository.java
@@ -1,9 +1,14 @@
 package kr.codesquad.issuetracker09.domain;
 
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface AssigneeRepository extends JpaRepository<Assignee, Long> {
     List<Assignee> findAssigneesByIssue_Id(Long id);
+
+    @SQLDelete(sql = "DELETE FROM assignee WHERE issue_id = :id")
+    void deleteByIssueId(@Param("id") Long issueId);
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
@@ -43,4 +43,8 @@ public class Issue {
 
     @OneToMany(mappedBy = "issue")
     private List<IssueHasLabel> issueHasLabelList = new ArrayList<>();
+
+    public void editMilestone(Milestone milestone) {
+        this.milestone = milestone;
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
@@ -42,7 +42,10 @@ public class Issue {
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "issue")
-    private List<IssueHasLabel> issueHasLabelList = new ArrayList<>();
+    private List<IssueHasLabel> issueHasLabels = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Assignee> assignees = new ArrayList<>();
 
     public void editMilestone(Milestone milestone) {
         this.milestone = milestone;

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
@@ -44,7 +44,7 @@ public class Issue {
     @OneToMany(mappedBy = "issue")
     private List<IssueHasLabel> issueHasLabels = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "issue")
     private List<Assignee> assignees = new ArrayList<>();
 
     public void editMilestone(Milestone milestone) {

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/IssueHasLabel.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/IssueHasLabel.java
@@ -1,9 +1,15 @@
 package kr.codesquad.issuetracker09.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Entity
 public class IssueHasLabel {

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/IssueHasLabelRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/IssueHasLabelRepository.java
@@ -16,4 +16,7 @@ public interface IssueHasLabelRepository extends JpaRepository<IssueHasLabel, Lo
 
     @SQLDelete(sql = "DELETE FROM issue_has_label WHERE label_id = :id")
     void deleteByLabelId(@Param("id") Long labelId);
+
+    @SQLDelete(sql = "DELETE FROM issue_has_label WHERE issue_id = :id")
+    void deleteByIssueId(@Param("id") Long issueId);
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/IssueHasLabelRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/IssueHasLabelRepository.java
@@ -1,6 +1,5 @@
 package kr.codesquad.issuetracker09.domain;
 
-import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
@@ -7,6 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -29,7 +31,6 @@ public class User {
     @Column(name = "email")
     private String email;
 
-    public static User insert(Long id, String name, Long socialId, String email) {
-        return new User(id, name, socialId, email);
-    }
+    @OneToMany(mappedBy = "user")
+    private List<Assignee> assigneeList = new ArrayList<>();
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/mock/MockIssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/mock/MockIssueController.java
@@ -88,7 +88,7 @@ public class MockIssueController {
     public void patchDeatil(@PathVariable(name = "issue-id") long issueId,
                             @RequestBody PatchDetailRequestDTO request,
                             HttpServletResponse response) {
-        log.debug("[*] put - issueId : {}, request : {}", issueId, request);
+        log.debug("[*] patch - issueId : {}, request : {}", issueId, request);
         response.setStatus(HttpStatus.OK.value());
     }
 

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/AssigneeService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/AssigneeService.java
@@ -2,13 +2,15 @@ package kr.codesquad.issuetracker09.service;
 
 import kr.codesquad.issuetracker09.domain.Assignee;
 import kr.codesquad.issuetracker09.domain.AssigneeRepository;
+import kr.codesquad.issuetracker09.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
 public class AssigneeService {
-    private AssigneeRepository assigneeRepository;
+    private final AssigneeRepository assigneeRepository;
 
     public AssigneeService(AssigneeRepository assigneeRepository) {
         this.assigneeRepository = assigneeRepository;
@@ -16,5 +18,18 @@ public class AssigneeService {
 
     public List<Assignee> findAllAssigneeByIssueId(Long issueId) {
         return assigneeRepository.findAssigneesByIssue_Id(issueId);
+    }
+
+    @Transactional
+    public void deleteByIssueId(Long issueId) {
+        assigneeRepository.deleteByIssueId(issueId);
+    }
+
+    public Assignee findById(Long id) {
+        return assigneeRepository.findById(id).orElseThrow(() -> new NotFoundException("Assignee doesn't exist."));
+    }
+
+    public void save(Assignee assignee) {
+        assigneeRepository.save(assignee);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/AssigneeService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/AssigneeService.java
@@ -1,0 +1,20 @@
+package kr.codesquad.issuetracker09.service;
+
+import kr.codesquad.issuetracker09.domain.Assignee;
+import kr.codesquad.issuetracker09.domain.AssigneeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AssigneeService {
+    private AssigneeRepository assigneeRepository;
+
+    public AssigneeService(AssigneeRepository assigneeRepository) {
+        this.assigneeRepository = assigneeRepository;
+    }
+
+    public List<Assignee> findAllAssigneeByIssueId(Long issueId) {
+        return assigneeRepository.findAssigneesByIssue_Id(issueId);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/IssueLabelService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/IssueLabelService.java
@@ -1,9 +1,11 @@
 package kr.codesquad.issuetracker09.service;
 
+import kr.codesquad.issuetracker09.domain.IssueHasLabel;
 import kr.codesquad.issuetracker09.domain.IssueHasLabelRepository;
 import kr.codesquad.issuetracker09.domain.Label;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
@@ -16,5 +18,14 @@ public class IssueLabelService {
 
     public List<Label> findLabelsByIssueId(Long issueId) {
         return issueHasLabelRepository.findLabelByIssueId(issueId);
+    }
+
+    @Transactional
+    public void deleteByIssueId(Long issueId) {
+        issueHasLabelRepository.deleteByIssueId(issueId);
+    }
+
+    public void save(IssueHasLabel issueHasLabel) {
+        issueHasLabelRepository.save(issueHasLabel);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/IssueService.java
@@ -2,19 +2,53 @@ package kr.codesquad.issuetracker09.service;
 
 import kr.codesquad.issuetracker09.domain.Issue;
 import kr.codesquad.issuetracker09.domain.IssueRepository;
+import kr.codesquad.issuetracker09.domain.Milestone;
+import kr.codesquad.issuetracker09.domain.MilestoneRepository;
+import kr.codesquad.issuetracker09.exception.NotFoundException;
+import kr.codesquad.issuetracker09.web.issue.dto.PatchDetailRequestDTO;
 import org.omg.CosNaming.NamingContextPackage.NotFound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class IssueService {
+    private static final Logger log = LoggerFactory.getLogger(IssueService.class);
     private IssueRepository issueRepository;
+    private MilestoneRepository milestoneRepository;
 
-    public IssueService(IssueRepository issueRepository) {
+    public IssueService(IssueRepository issueRepository, MilestoneRepository milestoneRepository) {
         this.issueRepository = issueRepository;
+        this.milestoneRepository = milestoneRepository;
     }
 
     public Issue findById(Long id) throws NotFound {
         Issue issue = issueRepository.findById(id).orElseThrow(NotFound::new);
         return issue;
+    }
+
+    public boolean editDetail(Long issueId, PatchDetailRequestDTO request) {
+        log.debug("[*] editDetail - issueId : {}, request : {}", issueId, request);
+        String targetKey = request.findNotNullField();
+        log.debug("[*] targetKey : {}", targetKey);
+        switch (targetKey) {
+            case "assignee":
+                break;
+            case "label":
+                break;
+            case "milestone":
+                milestoneUpdate(issueId, request.getMilestone());
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    public void milestoneUpdate(Long issueId, Long milestoneId) {
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new NotFoundException("Issue doesn't exist"));
+        Milestone milestone = milestoneRepository.findById(milestoneId).orElseThrow(() -> new NotFoundException("Milestone doesn't exit"));
+        issue.editMilestone(milestone);
+        issueRepository.save(issue);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/IssueService.java
@@ -1,9 +1,6 @@
 package kr.codesquad.issuetracker09.service;
 
-import kr.codesquad.issuetracker09.domain.Issue;
-import kr.codesquad.issuetracker09.domain.IssueRepository;
-import kr.codesquad.issuetracker09.domain.Milestone;
-import kr.codesquad.issuetracker09.domain.MilestoneRepository;
+import kr.codesquad.issuetracker09.domain.*;
 import kr.codesquad.issuetracker09.exception.NotFoundException;
 import kr.codesquad.issuetracker09.web.issue.dto.PatchDetailRequestDTO;
 import org.omg.CosNaming.NamingContextPackage.NotFound;
@@ -11,15 +8,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+import java.util.List;
+
 @Service
 public class IssueService {
     private static final Logger log = LoggerFactory.getLogger(IssueService.class);
     private IssueRepository issueRepository;
     private MilestoneRepository milestoneRepository;
+    private LabelRepository labelRepository;
+    private IssueLabelService issueLabelService;
 
-    public IssueService(IssueRepository issueRepository, MilestoneRepository milestoneRepository) {
+    public IssueService(IssueRepository issueRepository, MilestoneRepository milestoneRepository, LabelRepository labelRepository, IssueLabelService issueLabelService) {
         this.issueRepository = issueRepository;
         this.milestoneRepository = milestoneRepository;
+        this.labelRepository = labelRepository;
+        this.issueLabelService = issueLabelService;
     }
 
     public Issue findById(Long id) throws NotFound {
@@ -35,6 +39,7 @@ public class IssueService {
             case "assignee":
                 break;
             case "label":
+                labelUpdate(issueId, request.getLabel());
                 break;
             case "milestone":
                 milestoneUpdate(issueId, request.getMilestone());
@@ -50,5 +55,19 @@ public class IssueService {
         Milestone milestone = milestoneRepository.findById(milestoneId).orElseThrow(() -> new NotFoundException("Milestone doesn't exit"));
         issue.editMilestone(milestone);
         issueRepository.save(issue);
+    }
+
+    public void labelUpdate(Long issueId, List<Long> labelIds) {
+        log.debug("[*] labelUpdate - issudId : {}, labelsIds : {}", issueId, labelIds);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new NotFoundException("Issue doesn't exist"));
+        issueLabelService.deleteByIssueId(issueId);
+        for (Long labelId : labelIds) {
+            Label label = labelRepository.findById(labelId).orElseThrow(() -> new NotFoundException("Label doesn't exist"));
+            IssueHasLabel issueHasLabel = IssueHasLabel.builder()
+                    .issue(issue)
+                    .label(label)
+                    .build();
+            issueLabelService.save(issueHasLabel);
+        }
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
@@ -6,19 +6,18 @@ import kr.codesquad.issuetracker09.domain.Label;
 import kr.codesquad.issuetracker09.domain.Milestone;
 import kr.codesquad.issuetracker09.service.IssueLabelService;
 import kr.codesquad.issuetracker09.service.IssueService;
-import kr.codesquad.issuetracker09.service.LabelService;
 import kr.codesquad.issuetracker09.web.comment.dto.GetCommentListResponseDTO;
 import kr.codesquad.issuetracker09.web.issue.dto.GetIssueDetailResponseDTO;
+import kr.codesquad.issuetracker09.web.issue.dto.PatchDetailRequestDTO;
 import kr.codesquad.issuetracker09.web.label.dto.GetLabelListResponseDTO;
 import kr.codesquad.issuetracker09.web.milestone.dto.GetMilestoneListResponseDTO;
 import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,12 +28,10 @@ public class IssueController {
 
     private IssueService issueService;
     private IssueLabelService issueLabelService;
-    private LabelService labelService;
 
-    public IssueController(IssueService issueService, IssueLabelService issueLabelService, LabelService labelService) {
+    public IssueController(IssueService issueService, IssueLabelService issueLabelService) {
         this.issueService = issueService;
         this.issueLabelService = issueLabelService;
-        this.labelService = labelService;
     }
 
     @GetMapping("/{issue-id}/detail")
@@ -81,6 +78,17 @@ public class IssueController {
 
         detail.setLabels(labelDTOs);
         return detail;
+    }
+
+    @PatchMapping("/{issue-id}/detail")
+    public void editDetail(@PathVariable(name = "issue-id") Long issueId,
+                           @RequestBody PatchDetailRequestDTO request,
+                           HttpServletResponse response) {
+        log.debug("[*] patch - issueId : {}, request : {}", issueId, request);
+        if (issueService.editDetail(issueId, request)) {
+            response.setStatus(HttpStatus.OK.value());
+        }
+        //TODO : editDetail이 false(실패)인 경우 에러 처리
     }
 
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
@@ -1,12 +1,11 @@
 package kr.codesquad.issuetracker09.web.issue.controller;
 
-import kr.codesquad.issuetracker09.domain.Comment;
-import kr.codesquad.issuetracker09.domain.Issue;
-import kr.codesquad.issuetracker09.domain.Label;
-import kr.codesquad.issuetracker09.domain.Milestone;
+import kr.codesquad.issuetracker09.domain.*;
+import kr.codesquad.issuetracker09.service.AssigneeService;
 import kr.codesquad.issuetracker09.service.IssueLabelService;
 import kr.codesquad.issuetracker09.service.IssueService;
 import kr.codesquad.issuetracker09.web.comment.dto.GetCommentListResponseDTO;
+import kr.codesquad.issuetracker09.web.issue.dto.GetAssigneeListResponseDTO;
 import kr.codesquad.issuetracker09.web.issue.dto.GetIssueDetailResponseDTO;
 import kr.codesquad.issuetracker09.web.issue.dto.PatchDetailRequestDTO;
 import kr.codesquad.issuetracker09.web.label.dto.GetLabelListResponseDTO;
@@ -28,10 +27,12 @@ public class IssueController {
 
     private IssueService issueService;
     private IssueLabelService issueLabelService;
+    private AssigneeService assigneeService;
 
-    public IssueController(IssueService issueService, IssueLabelService issueLabelService) {
+    public IssueController(IssueService issueService, IssueLabelService issueLabelService, AssigneeService assigneeService) {
         this.issueService = issueService;
         this.issueLabelService = issueLabelService;
+        this.assigneeService = assigneeService;
     }
 
     @GetMapping("/{issue-id}/detail")
@@ -45,6 +46,16 @@ public class IssueController {
                 .open(issue.isOpen())
                 .build();
 
+        List<GetAssigneeListResponseDTO> getAssigneeListResponseDTOS = new ArrayList<>();
+        List<Assignee> assignees = assigneeService.findAllAssigneeByIssueId(issueId);
+        for (Assignee assignee : assignees) {
+            getAssigneeListResponseDTOS.add(GetAssigneeListResponseDTO.builder()
+                    .userId(assignee.getUser().getId())
+                    .userName(assignee.getUser().getName())
+                    .build());
+        }
+        detail.setAssignees(getAssigneeListResponseDTOS);
+
         List<GetCommentListResponseDTO> comments = new ArrayList<>();
         for (Comment comment : issue.getComments()) {
             comments.add(GetCommentListResponseDTO.builder()
@@ -54,7 +65,6 @@ public class IssueController {
                     .created(comment.getCreated())
                     .build());
         }
-
         detail.setComments(comments);
 
         Milestone milestone = issue.getMilestone();
@@ -75,7 +85,6 @@ public class IssueController {
                     .colorCode(label.getColorCode())
                     .build());
         }
-
         detail.setLabels(labelDTOs);
         return detail;
     }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/dto/GetAssigneeListResponseDTO.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/dto/GetAssigneeListResponseDTO.java
@@ -1,0 +1,15 @@
+package kr.codesquad.issuetracker09.web.issue.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class GetAssigneeListResponseDTO {
+    private Long userId;
+    private String userName;
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/dto/GetIssueDetailResponseDTO.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/dto/GetIssueDetailResponseDTO.java
@@ -18,9 +18,14 @@ public class GetIssueDetailResponseDTO {
     private String contents;
     private String author;
     private Boolean open;
+    private List<GetAssigneeListResponseDTO> assignees;
     private List<GetCommentListResponseDTO> comments;
     private List<GetLabelListResponseDTO> labels;
     private GetMilestoneListResponseDTO milestones;
+
+    public void setAssignees(List<GetAssigneeListResponseDTO> assignees) {
+        this.assignees = assignees;
+    }
 
     public void setComments(List<GetCommentListResponseDTO> comments) {
         this.comments = comments;

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/dto/PatchDetailRequestDTO.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/dto/PatchDetailRequestDTO.java
@@ -4,11 +4,30 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 @ToString
 public class PatchDetailRequestDTO {
-    private long assignee;
-    private long label;
-    private long milesttone;
+    private List<Long> assignee;
+    private List<Long> label;
+    private Long milestone;
+
+    public String findNotNullField() {
+        if (assignee != null) {
+            return "assignee";
+        }
+
+        if (label != null) {
+            return "label";
+        }
+
+        if (milestone != null) {
+            return "milestone";
+        }
+
+        return null;
+    }
 }

--- a/BE/src/main/resources/application-local.properties
+++ b/BE/src/main/resources/application-local.properties
@@ -14,6 +14,7 @@ spring.datasource.password=ENC(tr+rUEc1hg+ymH5lHeHcUmgYsFwk00BJ)
 spring.datasource.initialization-mode=always
 
 #JPA
-spring.jpa.hibernate.ddl-auto=create-drop
+#spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -34,3 +34,7 @@ INSERT INTO issue_has_label (issue_id, label_id) VALUES (1, 2);
 INSERT INTO issue_has_label (issue_id, label_id) VALUES (1, 3);
 INSERT INTO issue_has_label (issue_id, label_id) VALUES (2, 2);
 INSERT INTO issue_has_label (issue_id, label_id) VALUES (2, 3);
+
+INSERT INTO assignee (issue_id, user_id) VALUES (1, 1);
+INSERT INTO assignee (issue_id, user_id) VALUES (1, 2);
+INSERT INTO assignee (issue_id, user_id) VALUES (2, 2);


### PR DESCRIPTION
IssueController
- patch 처리 컨트롤러 추가
- editDetail이 성공하면 200 응답
IssueService - editDetail()
- 업데이트할 타겟 필드를 switch~case로 찾아서 해당 필드를 업데이트하도록 함
- milestone일 경우, milestoneUpdate 메서드로 해당 이슈의 milestone을 수정
 issueId로 해당 issue 정보를 가져와서 milestone정보를 수정 후, issueRepository로 save → 기존에 존재하는 이슈이므로 update 진행
PatchDetailRequestDTO
- findNotNullField() : 업데이트 하려는 타겟 필드를 반환

- Assignee(담당자) 테이블 생성하고 엔티티로 승격
- Issue에 담당자 정보를 저장하기 위해 User와 M:N 매핑을 중계테이블인 Assignee로 구현