### PR TITLE
[BE] Coment API 기능 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker09/common/WebMvcConfig.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/common/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker09.common;
 
+import kr.codesquad.issuetracker09.domain.UserRepository;
 import kr.codesquad.issuetracker09.service.JwtService;
 import kr.codesquad.issuetracker09.service.UserService;
 import org.springframework.context.annotation.Bean;
@@ -12,15 +13,17 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     JwtService jwtService;
     UserService userService;
+    UserRepository userRepository;
 
-    public WebMvcConfig(JwtService jwtService, UserService userService) {
+    public WebMvcConfig(JwtService jwtService, UserService userService, UserRepository userRepository) {
         this.jwtService = jwtService;
         this.userService = userService;
+        this.userRepository = userRepository;
     }
 
     @Bean
     public AuthCheckInterceptor authCheckInterceptor() {
-        return new AuthCheckInterceptor(jwtService, userService);
+        return new AuthCheckInterceptor(jwtService, userService, userRepository);
     }
 
     @Override

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Comment.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Comment.java
@@ -3,11 +3,11 @@ package kr.codesquad.issuetracker09.domain;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+@Setter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ToString
 @Getter

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Issue.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker09.domain;
 
+import kr.codesquad.issuetracker09.web.comment.dto.PostRequestDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,10 +38,19 @@ public class Issue {
     @JoinColumn(name = "USER_ID")
     private User author;
 
-    @OneToMany
+    @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "ISSUE_ID")
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "issue")
     private List<IssueHasLabel> issueHasLabelList = new ArrayList<>();
+
+    public void addComment(User user, PostRequestDTO commentDTO) {
+        Comment comment = new Comment.CommentBuilder()
+                .contents(commentDTO.getContents())
+                .author(user)
+                .created(LocalDateTime.now())
+                .build();
+        comments.add(comment);
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
@@ -29,7 +29,4 @@ public class User {
     @Column(name = "email")
     private String email;
 
-    public static User insert(Long id, String name, Long socialId, String email) {
-        return new User(id, name, socialId, email);
-    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
@@ -46,7 +46,9 @@ public class CommentService {
         List<Comment> commentList = issue.getComments();
 
         for (Comment comment : commentList) {
+
             if (comment.getId().equals(commentId)) {
+
                 if (!checkUser(comment, authorId)) {
                     return false;
                 }
@@ -58,6 +60,26 @@ public class CommentService {
         issueRepository.save(issue);
         return true;
     }
+
+    public boolean delete(Long issueId, Long authorId, Long commentId) throws NotFound {
+        Issue issue = issueRepository.findById(issueId).orElseThrow(NotFound::new);
+        List<Comment> commentList = issue.getComments();
+
+        for (Comment comment : commentList) {
+
+            if (comment.getId().equals(commentId)) {
+
+                if (!checkUser(comment, authorId)) {
+                    return false;
+                }
+                commentList.remove(comment);
+                break;
+            }
+        }
+        issueRepository.save(issue);
+        return true;
+    }
+
 
     private boolean checkUser(Comment comment, Long authorId) {
         User author = comment.getAuthor();

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
@@ -1,0 +1,37 @@
+package kr.codesquad.issuetracker09.service;
+
+import kr.codesquad.issuetracker09.domain.Issue;
+import kr.codesquad.issuetracker09.domain.IssueRepository;
+import kr.codesquad.issuetracker09.domain.User;
+import kr.codesquad.issuetracker09.exception.ValidationException;
+import kr.codesquad.issuetracker09.web.comment.dto.PostRequestDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.omg.CosNaming.NamingContextPackage.NotFound;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Slf4j
+@Transactional
+@Service
+public class CommentService {
+
+    private IssueRepository issueRepository;
+    private UserService userService;
+
+    public CommentService(IssueRepository issueRepository, UserService userService) {
+        this.issueRepository = issueRepository;
+        this.userService = userService;
+    }
+
+    public void save(Long issueId, Long authorId, PostRequestDTO commentDTO) throws NotFound{
+        Issue issue = issueRepository.findById(issueId).orElseThrow(NotFound::new);
+        if (commentDTO.getContents() == null) {
+            throw new ValidationException("Contents can't be blank");
+        }
+        User user = userService.findUser(authorId);
+        log.debug("[*] user : {}", user);
+        issue.addComment(user, commentDTO);
+        issueRepository.save(issue);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker09.service;
 
+import kr.codesquad.issuetracker09.domain.Comment;
 import kr.codesquad.issuetracker09.domain.Issue;
 import kr.codesquad.issuetracker09.domain.IssueRepository;
 import kr.codesquad.issuetracker09.domain.User;
@@ -10,6 +11,8 @@ import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Transactional
@@ -24,7 +27,7 @@ public class CommentService {
         this.userService = userService;
     }
 
-    public void save(Long issueId, Long authorId, PostRequestDTO commentDTO) throws NotFound{
+    public void save(Long issueId, Long authorId, PostRequestDTO commentDTO) throws NotFound {
         Issue issue = issueRepository.findById(issueId).orElseThrow(NotFound::new);
         if (commentDTO.getContents() == null) {
             throw new ValidationException("Contents can't be blank");
@@ -32,6 +35,24 @@ public class CommentService {
         User user = userService.findUser(authorId);
         log.debug("[*] user : {}", user);
         issue.addComment(user, commentDTO);
+        issueRepository.save(issue);
+    }
+
+    public void edit(Long issueId, Long authorId, Long commentId, PostRequestDTO commentDTO) throws NotFound {
+        Issue issue = issueRepository.findById(issueId).orElseThrow(NotFound::new);
+        if (commentDTO.getContents() == null) {
+            throw new ValidationException("Contents can't be blank");
+        }
+        List<Comment> commentList = issue.getComments();
+
+        for (Comment comment : commentList) {
+
+            if (comment.getId().equals(commentId)) {
+                comment.setContents(commentDTO.getContents());
+                comment.setCreated(LocalDateTime.now());
+                break;
+            }
+        }
         issueRepository.save(issue);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/CommentService.java
@@ -38,7 +38,7 @@ public class CommentService {
         issueRepository.save(issue);
     }
 
-    public void edit(Long issueId, Long authorId, Long commentId, PostRequestDTO commentDTO) throws NotFound {
+    public boolean edit(Long issueId, Long authorId, Long commentId, PostRequestDTO commentDTO) throws NotFound {
         Issue issue = issueRepository.findById(issueId).orElseThrow(NotFound::new);
         if (commentDTO.getContents() == null) {
             throw new ValidationException("Contents can't be blank");
@@ -46,13 +46,21 @@ public class CommentService {
         List<Comment> commentList = issue.getComments();
 
         for (Comment comment : commentList) {
-
             if (comment.getId().equals(commentId)) {
+                if (!checkUser(comment, authorId)) {
+                    return false;
+                }
                 comment.setContents(commentDTO.getContents());
                 comment.setCreated(LocalDateTime.now());
                 break;
             }
         }
         issueRepository.save(issue);
+        return true;
+    }
+
+    private boolean checkUser(Comment comment, Long authorId) {
+        User author = comment.getAuthor();
+        return author.getId().equals(authorId);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
@@ -106,4 +106,14 @@ public class IssueController {
         response.setStatus(HttpStatus.NO_CONTENT.value());
     }
 
+    @DeleteMapping("/{issue-id}/comments/{comment-id}")
+    public void delete(@PathVariable(name = "issue-id") Long issueId, @PathVariable(name = "comment-id") Long commentId,
+                       @RequestAttribute("id") Long authorId, HttpServletResponse response) throws NotFound {
+        if(!commentService.delete(issueId, authorId, commentId)) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return;
+        }
+        response.setStatus(HttpStatus.NO_CONTENT.value());
+    }
+
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
@@ -95,4 +95,12 @@ public class IssueController {
         response.setStatus(HttpStatus.CREATED.value());
     }
 
+    @PutMapping("/{issue-id}/comments/{comment-id}")
+    public void edit(@PathVariable(name = "issue-id") Long issueId, @PathVariable(name = "comment-id") Long commentId,
+                     @RequestBody PostRequestDTO commentDTO, @RequestAttribute("id") Long authorId,
+                     HttpServletResponse response) throws NotFound {
+        commentService.edit(issueId, authorId, commentId, commentDTO);
+        response.setStatus(HttpStatus.NO_CONTENT.value());
+    }
+
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
@@ -4,21 +4,22 @@ import kr.codesquad.issuetracker09.domain.Comment;
 import kr.codesquad.issuetracker09.domain.Issue;
 import kr.codesquad.issuetracker09.domain.Label;
 import kr.codesquad.issuetracker09.domain.Milestone;
+import kr.codesquad.issuetracker09.service.CommentService;
 import kr.codesquad.issuetracker09.service.IssueLabelService;
 import kr.codesquad.issuetracker09.service.IssueService;
 import kr.codesquad.issuetracker09.service.LabelService;
 import kr.codesquad.issuetracker09.web.comment.dto.GetCommentListResponseDTO;
+import kr.codesquad.issuetracker09.web.comment.dto.PostRequestDTO;
 import kr.codesquad.issuetracker09.web.issue.dto.GetIssueDetailResponseDTO;
 import kr.codesquad.issuetracker09.web.label.dto.GetLabelListResponseDTO;
 import kr.codesquad.issuetracker09.web.milestone.dto.GetMilestoneListResponseDTO;
 import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,11 +31,13 @@ public class IssueController {
     private IssueService issueService;
     private IssueLabelService issueLabelService;
     private LabelService labelService;
+    private CommentService commentService;
 
-    public IssueController(IssueService issueService, IssueLabelService issueLabelService, LabelService labelService) {
+    public IssueController(IssueService issueService, IssueLabelService issueLabelService, LabelService labelService, CommentService commentService) {
         this.issueService = issueService;
         this.issueLabelService = issueLabelService;
         this.labelService = labelService;
+        this.commentService = commentService;
     }
 
     @GetMapping("/{issue-id}/detail")
@@ -81,6 +84,15 @@ public class IssueController {
 
         detail.setLabels(labelDTOs);
         return detail;
+    }
+
+    @PostMapping("/{issue-id}/comments")
+    public void create(@PathVariable(name = "issue-id") Long issueId, @RequestBody PostRequestDTO commentDTO,
+                       @RequestAttribute("id") Long authorId, HttpServletResponse response) throws NotFound {
+        log.debug("[*] create - comment : {}", commentDTO);
+        log.debug("[*] create - authorId : {}", authorId);
+        commentService.save(issueId, authorId, commentDTO);
+        response.setStatus(HttpStatus.CREATED.value());
     }
 
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/issue/controller/IssueController.java
@@ -99,7 +99,10 @@ public class IssueController {
     public void edit(@PathVariable(name = "issue-id") Long issueId, @PathVariable(name = "comment-id") Long commentId,
                      @RequestBody PostRequestDTO commentDTO, @RequestAttribute("id") Long authorId,
                      HttpServletResponse response) throws NotFound {
-        commentService.edit(issueId, authorId, commentId, commentDTO);
+        if (!commentService.edit(issueId, authorId, commentId, commentDTO)) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return;
+        }
         response.setStatus(HttpStatus.NO_CONTENT.value());
     }
 

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -1,7 +1,10 @@
 INSERT INTO user (social_id, name, email)
 VALUES (123123, 'Solar', 'solar@gmail.com');
 INSERT INTO user (social_id, name, email)
-VALUES (321321, 'Poogle', 'poogle@gmail.com');
+VALUES (321321, 'sssss', 'ssss@gmail.com');
+INSERT INTO user (social_id, name, email)
+VALUES (58318786, 'Poogle', null);
+
 
 INSERT INTO label (title, color_code)
 VALUES ("TEAM", "#123aaa");
@@ -21,13 +24,6 @@ INSERT INTO issue (title, contents, created, open, is_deleted, user_id, mileston
 VALUES ("issue 1", "first issue blabla", "2020-06-18", TRUE, FALSE, 1, 1);
 INSERT INTO issue (title, contents, created, open, is_deleted, user_id, milestone_id)
 VALUES ("issue 2", "second issue blabla", "2020-06-18", TRUE, FALSE, 2, 2);
-
-INSERT INTO comment (contents, user_id, created, issue_id)
-VALUES ("Good!!", 2, "2020-06-19 13:01:23", 1);
-INSERT INTO comment (contents, user_id, created, issue_id)
-VALUES ("OKOK!!", 1, "2020-06-19 13:21:34", 1);
-INSERT INTO comment (contents, user_id, created, issue_id)
-VALUES ("Hi!!", 2, "2020-06-19 13:34:11", 1);
 
 INSERT INTO issue_has_label (issue_id, label_id) VALUES (1, 1);
 INSERT INTO issue_has_label (issue_id, label_id) VALUES (1, 2);


### PR DESCRIPTION
* Comment 생성, 수정, 삭제 api 구현
* 댓글 작성자와 수정, 삭제하려는 사용자가 다를 경우 예외처리 (403)
* 현재 comment는 Issue와 동일한 어그리게이트라고 생각되어, commentRepository를 만들지 않고 IssueRepository만 만들어서 접근

* issue id로 issue를 찾고 해당 issue의 comment list를 탐색한다.
* 수정, 삭제하려는 comment id와 동일한 comment를 해당 이슈의 comment list에서 찾는다.
* 변경사항을 반영해 issue를 다시 저장한다.