### PR TITLE
[BE] Apple Login 수정사항 반영

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker09/common/AuthCheckInterceptor.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/common/AuthCheckInterceptor.java
@@ -30,7 +30,7 @@ public class AuthCheckInterceptor implements HandlerInterceptor {
         String jwt = request.getHeader(HEADER_AUTH);
 
         if (jwt != null) {
-            Long socialId = jwtService.parseJwt(jwt).getSocialId();
+            String socialId = jwtService.parseJwt(jwt).getSocialId();
             log.debug("[*] socialId : {}", socialId);
             User user = userRepository.findUserBySocialId(socialId).orElseThrow(NotFound::new);
             log.debug("[*] user : {}", user);

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
@@ -26,7 +26,7 @@ public class User {
 
     @JsonProperty("social_id")
     @Column(name = "social_id")
-    private Long socialId;
+    private String socialId;
 
     @Column(name = "email")
     private String email;

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/UserRepository.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/UserRepository.java
@@ -1,10 +1,9 @@
 package kr.codesquad.issuetracker09.domain;
 
-import kr.codesquad.issuetracker09.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findUserBySocialId(Long socialId);
+    Optional<User> findUserBySocialId(String socialId);
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/JwtService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/JwtService.java
@@ -1,26 +1,34 @@
 package kr.codesquad.issuetracker09.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import kr.codesquad.issuetracker09.domain.User;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
-
+@Slf4j
 @Service
 public class JwtService {
 
     private final String JWT_KEY;
+    private final String APPLE_KEY;
+    private final String APPLE_ID;
     private SecretKey key;
 
     public JwtService(Environment env) {
         JWT_KEY = env.getProperty("JWT_KEY");
+        APPLE_KEY = env.getProperty("APPLE_KEY");
+        APPLE_ID = env.getProperty("APPLE_ID");
         key = Keys.hmacShaKeyFor(JWT_KEY.getBytes());
     }
 
@@ -41,7 +49,9 @@ public class JwtService {
                 .getBody();
         Long id = claims.get("id", Long.class);
         String name = (String) claims.get("name");
-        Long socialId = claims.get("socialId", Long.class);
+        log.debug("[*] name: {}", name);
+        String socialId = (String) claims.get("socialId");
+        log.debug("[*] socialId: {}", socialId);
         String email = (String) claims.get("email");
         return User.builder()
                 .id(id)
@@ -67,4 +77,41 @@ public class JwtService {
         return payloads;
     }
 
+    public boolean checkAppleValidation(Map<String, Object> payloads) {
+        String registeredKey = (String) payloads.get("iss");
+        String account = (String) payloads.get("aud");
+        log.debug("[*] keyCheck: {}", registeredKey.equals(APPLE_KEY));
+        log.debug("[*] idCheck: {}", account.equals(APPLE_ID));
+        return (registeredKey.equals(APPLE_KEY) && account.equals(APPLE_ID));
+    }
+
+    public Map<String, Object> getTokenPayload(String jwt) {
+        Map<String, Object> payloadMap = new HashMap<>();
+        ObjectMapper om = new ObjectMapper();
+        String encodedTokenPayload = jwt.split("\\.")[1];
+        Base64.Decoder decoder = Base64.getDecoder();
+        String tokenPayload = new String(decoder.decode(encodedTokenPayload));
+        try {
+            payloadMap = om.readValue(tokenPayload, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (Exception e) {
+            System.out.println("[getTokenPayload] + " + e.getMessage());
+        }
+        return payloadMap;
+    }
+
+    public User parseAppleJwt(Map<String, Object> payloads) {
+        log.debug("[*] claims: {}", payloads);
+        String socialId = (String) payloads.get("sub");
+        log.debug("[*] socialId: {}", socialId);
+        String email = (String) payloads.get("email");
+        log.debug("[*] email: {}", email);
+        String name = email.substring(0, email.indexOf("@"));
+        log.debug("[*] name: {}", name);
+        return User.builder()
+                .name(name)
+                .socialId(socialId)
+                .email(email)
+                .build();
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/OAuthService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/OAuthService.java
@@ -31,7 +31,7 @@ public class OAuthService {
     }
 
     public GithubToken getAccessToken(String code) {
-        MultiValueMap<String ,String> headers = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
         Map<String, String> header = new HashMap<>();
         header.put("Accept", "application/json");
         headers.setAll(header);
@@ -55,7 +55,7 @@ public class OAuthService {
         if (response.getStatusCode() == HttpStatus.OK) {
             JsonNode jsonNode = objectMapper.readTree(response.getBody());
             return User.builder()
-                    .socialId(jsonNode.required("id").asLong())
+                    .socialId(jsonNode.required("id").asText())
                     .name(jsonNode.required("name").asText())
                     .email(jsonNode.required("email").asText())
                     .build();

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/login/dto/PostRequestDTO.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/login/dto/PostRequestDTO.java
@@ -1,0 +1,13 @@
+package kr.codesquad.issuetracker09.web.login.dto;
+
+import lombok.*;
+
+@ToString
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequestDTO {
+
+    private String jwtToken;
+}


### PR DESCRIPTION
### User DB 수정사항
* social id를 Long -> String 타입으로 변경
    * Github, Apple 로그인 정보 통합하기 위해서

### 수정된 Apple Login 과정
* 로그인 후 클라이언트에서 jwt 발급 받음
* jwt 토큰 파싱해서 유효성 검사
* 유효한 유저의 경우 DB에 유저 정보 저장 후 Response: 200
* 유효하지 않은 유저의 경우 Response: 401