### PR TITLE
[BE] social user에 따른 토큰 구분

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker09/common/AuthCheckInterceptor.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/common/AuthCheckInterceptor.java
@@ -11,10 +11,12 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
 
 @Slf4j
 public class AuthCheckInterceptor implements HandlerInterceptor {
     private final String HEADER_AUTH = "Authorization";
+    private final String LOGIN_TYPE = "LoginType";
     private final JwtService jwtService;
     private final UserService userService;
     private final UserRepository userRepository;
@@ -27,18 +29,22 @@ public class AuthCheckInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String loginType = request.getHeader(LOGIN_TYPE);
         String jwt = request.getHeader(HEADER_AUTH);
-
-        if (jwt != null) {
-            String socialId = jwtService.parseJwt(jwt).getSocialId();
-            log.debug("[*] socialId : {}", socialId);
-            User user = userRepository.findUserBySocialId(socialId).orElseThrow(NotFound::new);
-            log.debug("[*] user : {}", user);
-            log.debug("[*] userId : {}", user.getId());
-            request.setAttribute("id", user.getId());
-        } else {
+        if (jwt == null) {
             throw AuthorizationException.emptyToken();
         }
+        String socialId;
+        if (loginType.equals("github")) {
+            socialId = jwtService.parseGithubJwt(jwt).getSocialId();
+        } else if (loginType.equals("apple")) {
+            Map<String, Object> payloads = jwtService.getTokenPayload(jwt);
+            socialId = jwtService.parseAppleJwt(payloads).getSocialId();
+        } else {
+            throw new AuthorizationException("invalid token");
+        }
+        User user = userRepository.findUserBySocialId(socialId).orElseThrow(NotFound::new);
+        request.setAttribute("id", user.getId());
         return true;
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Label.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Label.java
@@ -27,6 +27,7 @@ public class Label {
     @Column(name="color_code")
     private String colorCode;
 
+    @Builder.Default
     @JsonIgnore
     @OneToMany(mappedBy = "label")
     private List<IssueHasLabel> issueHasLabelList = new ArrayList<>();

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/Milestone.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/Milestone.java
@@ -26,6 +26,7 @@ public class Milestone {
     @Column(name = "due_on")
     private LocalDate dueOn;
 
+    @Builder.Default
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @OneToMany(mappedBy = "milestone")
     private List<Issue> issues = new ArrayList<>();

--- a/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/domain/User.java
@@ -31,6 +31,7 @@ public class User {
     @Column(name = "email")
     private String email;
 
+    @Builder.Default
     @OneToMany(mappedBy = "user")
     private List<Assignee> assigneeList = new ArrayList<>();
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker09/service/JwtService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/service/JwtService.java
@@ -40,7 +40,7 @@ public class JwtService {
                 .compact();
     }
 
-    public User parseJwt(String jwt) {
+    public User parseGithubJwt(String jwt) {
         jwt = jwt.replace("Bearer ", "");
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(key)
@@ -49,9 +49,7 @@ public class JwtService {
                 .getBody();
         Long id = claims.get("id", Long.class);
         String name = (String) claims.get("name");
-        log.debug("[*] name: {}", name);
         String socialId = (String) claims.get("socialId");
-        log.debug("[*] socialId: {}", socialId);
         String email = (String) claims.get("email");
         return User.builder()
                 .id(id)
@@ -80,8 +78,6 @@ public class JwtService {
     public boolean checkAppleValidation(Map<String, Object> payloads) {
         String registeredKey = (String) payloads.get("iss");
         String account = (String) payloads.get("aud");
-        log.debug("[*] keyCheck: {}", registeredKey.equals(APPLE_KEY));
-        log.debug("[*] idCheck: {}", account.equals(APPLE_ID));
         return (registeredKey.equals(APPLE_KEY) && account.equals(APPLE_ID));
     }
 
@@ -101,13 +97,9 @@ public class JwtService {
     }
 
     public User parseAppleJwt(Map<String, Object> payloads) {
-        log.debug("[*] claims: {}", payloads);
         String socialId = (String) payloads.get("sub");
-        log.debug("[*] socialId: {}", socialId);
         String email = (String) payloads.get("email");
-        log.debug("[*] email: {}", email);
         String name = email.substring(0, email.indexOf("@"));
-        log.debug("[*] name: {}", name);
         return User.builder()
                 .name(name)
                 .socialId(socialId)

--- a/BE/src/main/java/kr/codesquad/issuetracker09/web/login/controller/LoginController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker09/web/login/controller/LoginController.java
@@ -38,6 +38,7 @@ public class LoginController {
         User user = oAuthService.getSocialUser(code);
         userService.insertOrUpdateUser(user);
         String jwt = jwtService.buildJwt(user);
+        log.debug("[*] jwt: {}", jwt);
         response.sendRedirect("issuenine://oauth?token=" + jwt);
         return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT).body("redirect");
     }


### PR DESCRIPTION
### Custom Request Header 추가
* github과 apple 유저에 따라 토큰을 파싱할 때 필요한 key가 다름을 확인
* 구분하는 로직을 추가하기 위해 custom header를 만든다.

### Builder 어노테이션
* `@Builder.Default` 어노테이션을 추가해 빌드 시 경고 없애기
* mappedBy 된 필드에 추가한 것으로 확인