### PR TITLE
네트워크 구현 부분 구체타입 제거

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Label/CreateLabel/LabelFormViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Label/CreateLabel/LabelFormViewController.swift
@@ -49,7 +49,7 @@ final class LabelFormViewController: CategoryFormViewController {
     
     private func request(label: Label, method: HTTPMethod) {
         UseCase.shared
-            .fetch(label,
+            .fetch(data: label,
                   endpoint: Endpoint(path: generatePath(method: method, identity: label.id)),
                   method: method)
             .receive(on: RunLoop.main)

--- a/iOS/IssueTracker/IssueTracker/Login/LoginManager.swift
+++ b/iOS/IssueTracker/IssueTracker/Login/LoginManager.swift
@@ -34,7 +34,7 @@ class LoginManager: NSObject {
         guard let tokenData = credential.identityToken,
             let token = String(data: tokenData, encoding: .utf8) else { return }
         UseCase.shared
-            .request(AppleLogin(token: token),
+            .request(data: AppleLogin(token: token),
                      endpoint: Endpoint(path: .appleLogin),
                      method: .post)
             .receive(subscriber: Subscribers.Sink(receiveCompletion: { [weak self] in

--- a/iOS/IssueTracker/IssueTracker/MileStone/CreateMileStone/MileStoneFormViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MileStone/CreateMileStone/MileStoneFormViewController.swift
@@ -48,7 +48,7 @@ final class MileStoneFormViewController: CategoryFormViewController {
     
     private func request(_ mileStone: DeficientMileStone, method: HTTPMethod) {
         UseCase.shared
-            .fetch(mileStone,
+            .fetch(data: mileStone,
                   endpoint: Endpoint(path: generatePath(method: method, identity: mileStone.id)),
                   method: method)
             .receive(on: RunLoop.main)

--- a/iOS/IssueTracker/IssueTracker/MileStone/MileStoneTableViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/MileStone/MileStoneTableViewController.swift
@@ -28,7 +28,7 @@ final class MileStoneTableViewController: CategoryTableViewController {
     // MARK: - Methods
     func fetchMileStones() {
         UseCase.shared
-            .fetch([DeficientMileStone].self,
+            .fetch(type: [DeficientMileStone].self,
                    endpoint: Endpoint(path: .mileStone()),
                    method: .get)
             .receive(on: RunLoop.main)

--- a/iOS/IssueTracker/IssueTracker/Network/Usable.swift
+++ b/iOS/IssueTracker/IssueTracker/Network/Usable.swift
@@ -31,8 +31,8 @@ enum HTTPMethod: CustomStringConvertible {
 }
 
 protocol Usable {
-    func fetch<D: Decodable>(_ type: D.Type, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<D, IssueTrackerNetworkError>
-    func request(endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError>
-    func request<E: Encodable>(_ data: E, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError>
-    func fetch<C: Codable>(_ data: C, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<(data: C?, response: HTTPURLResponse?), IssueTrackerNetworkError>
+    func fetch<D: Decodable>(_ network: IssueTrackerNetwork, type: D.Type, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<D, IssueTrackerNetworkError>
+    func request(_ network: IssueTrackerNetwork, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError>
+    func request<E: Encodable>(_ network: IssueTrackerNetwork, data: E, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError>
+    func fetch<C: Codable>(_ network: IssueTrackerNetwork, data: C, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<(data: C?, response: HTTPURLResponse?), IssueTrackerNetworkError>
 }

--- a/iOS/IssueTracker/IssueTracker/Network/UsableImpl.swift
+++ b/iOS/IssueTracker/IssueTracker/Network/UsableImpl.swift
@@ -19,12 +19,12 @@ struct UseCase: Usable {
     private init() { }
     
     // MARK: - Methods
-    func fetch<D: Decodable>(_ type: D.Type, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<D, IssueTrackerNetworkError> {
+    func fetch<D: Decodable>(_ network: IssueTrackerNetwork = IssueTrackerNetworkImpl.shared, type: D.Type, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<D, IssueTrackerNetworkError> {
         guard let url = endpoint.url else {
             return Fail(error: IssueTrackerNetworkError.urlError).eraseToAnyPublisher()
         }
         
-        return IssueTrackerNetworkImpl.shared
+        return network
             .request(request: URLRequest(url: url,
                                          method: method))
             .map { $0.data }
@@ -33,12 +33,12 @@ struct UseCase: Usable {
             .eraseToAnyPublisher()
     }
     
-    func request(endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError> {
+    func request(_ network: IssueTrackerNetwork = IssueTrackerNetworkImpl.shared, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError> {
         guard let url = endpoint.url else {
             return Fail(error: IssueTrackerNetworkError.urlError).eraseToAnyPublisher()
         }
         
-        return IssueTrackerNetworkImpl.shared
+        return network
             .request(request: URLRequest(url: url,
                                          method: method))
             .compactMap { $0.response as? HTTPURLResponse }
@@ -46,7 +46,7 @@ struct UseCase: Usable {
             .eraseToAnyPublisher()
     }
     
-    func request<E: Encodable>(_ data: E, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError> {
+    func request<E: Encodable>(_ network: IssueTrackerNetwork = IssueTrackerNetworkImpl.shared, data: E, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<HTTPURLResponse, IssueTrackerNetworkError> {
         guard let url = endpoint.url else {
             return Fail(error: IssueTrackerNetworkError.urlError).eraseToAnyPublisher()
         }
@@ -54,7 +54,7 @@ struct UseCase: Usable {
             return Fail(error: IssueTrackerNetworkError.jsonEncodingError).eraseToAnyPublisher()
         }
         
-        return IssueTrackerNetworkImpl.shared
+        return network
             .request(request: URLRequest(url: url,
                                          method: method,
                                          body: data))
@@ -63,23 +63,23 @@ struct UseCase: Usable {
             .eraseToAnyPublisher()
     }
     
-    func fetch<C>(_ data: C, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<(data: C?, response: HTTPURLResponse?), IssueTrackerNetworkError> where C : Decodable,
-    C: Encodable {
-        guard let url = endpoint.url else {
-            return Fail(error: IssueTrackerNetworkError.urlError).eraseToAnyPublisher()
-        }
-        guard let data = try? JSONEncoder().encode(data) else {
-            return Fail(error: IssueTrackerNetworkError.jsonEncodingError).eraseToAnyPublisher()
-        }
-        
-        return IssueTrackerNetworkImpl.shared
-            .request(request: URLRequest(url: url,
-                                         method: method,
-                                         body: data))
-            .map({ data, response in
-                return (try? self.decoder.decode(C.self, from: data), response as? HTTPURLResponse)
-            })
-            .mapError { _ in IssueTrackerNetworkError.jsonDecodingError }
-            .eraseToAnyPublisher()
+    func fetch<C>(_ network: IssueTrackerNetwork = IssueTrackerNetworkImpl.shared, data: C, endpoint: RequestProviding, method: HTTPMethod) -> AnyPublisher<(data: C?, response: HTTPURLResponse?), IssueTrackerNetworkError> where C : Decodable,
+        C: Encodable {
+            guard let url = endpoint.url else {
+                return Fail(error: IssueTrackerNetworkError.urlError).eraseToAnyPublisher()
+            }
+            guard let data = try? JSONEncoder().encode(data) else {
+                return Fail(error: IssueTrackerNetworkError.jsonEncodingError).eraseToAnyPublisher()
+            }
+            
+            return network
+                .request(request: URLRequest(url: url,
+                                             method: method,
+                                             body: data))
+                .map({ data, response in
+                    return (try? self.decoder.decode(C.self, from: data), response as? HTTPURLResponse)
+                })
+                .mapError { _ in IssueTrackerNetworkError.jsonDecodingError }
+                .eraseToAnyPublisher()
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Supports/LabelTableViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Supports/LabelTableViewController.swift
@@ -33,7 +33,7 @@ final class LabelTableViewController: CategoryTableViewController {
     // MARK: - Methods
     func fetchLabels() {
         UseCase.shared
-            .fetch([Label].self,
+            .fetch(type: [Label].self,
                     endpoint: Endpoint(path: .labels()),
                     method: .get)
             .receive(on: RunLoop.main)


### PR DESCRIPTION
프로토콜을 사용헤서 유연하게 대응할 수 있었던 부분을 구체타입을 사용해서 구현했었습니다. 프로토콜을 사용하는 이유가 없었기 때문에 구체타입을 제거하고 프로토콜을 사용하도록 수정했습니다.
